### PR TITLE
Modernize Python practices

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: ["**"]
+    branches: ["master"]
   pull_request:
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.12", "3.14"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: pip install -e ".[dev]"
+
+      - name: Run tests
+        run: python -m pytest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,12 +15,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v5
+      - uses: astral-sh/setup-uv@v5
         with:
           python-version: ${{ matrix.python-version }}
 
       - name: Install dependencies
-        run: pip install -e ".[dev]"
+        run: uv sync --extra dev
 
       - name: Run tests
-        run: python -m pytest
+        run: uv run pytest


### PR DESCRIPTION
## Summary

- **Modernize `rockethook/__init__.py`**: drop Python 2 compat aliases, add type hints, f-strings, `super()`, `isinstance` guard, specific exception handling, `__all__`
- **Replace `setup.py` with `pyproject.toml`**: PEP 517/621 compliant packaging; `pytest` declared as a dev dependency
- **Add unit test suite** (`tests/test_rockethook.py`): 35 pytest tests covering `WebhookError`, `Message`, `Webhook` construction, `post`/`quick_post` behaviour, and public API — HTTP connections mocked, no network access required
- **Add GitHub Actions CI**: runs `uv sync --extra dev` + `pytest` on Python 3.8, 3.12, and 3.14
- **Fix author name**: Gennady → Gennadii in `LICENSE` and `pyproject.toml`

## Test plan

- [x] All 35 tests pass locally (`python -m pytest`)
- [ ] CI passes on all three Python versions in the matrix